### PR TITLE
Fix paths on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,8 +1,5 @@
 ---
 layout: default
-color:
-  primary: "#4c158a"
-  primary-text: "#fff"
 permalink: /404.html
 ---
 
@@ -14,13 +11,13 @@ permalink: /404.html
   <p>The app or page you’re looking for isn’t here. You can try browsing for it among the {{apps | size}} apps on the homepage, or if you’re on Endless OS, try searching in App Center.</p>
   <div class="action">
     <a id="open-appcenter" class="button" href="appstream://">Search App Center</a>
-    <a class="button suggested" href="/">Visit Homepage</a>
+    <a class="button suggested" href="{{ site.baseurl }}">Visit Homepage</a>
   </div>
 </div>
 
 <footer>
   <div class="constrain">
-    <a class="button go-home" href="/">All Apps</a>
+    <a class="button go-home" href="{{ site.baseurl }}">All Apps</a>
   </div>
 </footer>
 


### PR DESCRIPTION
Super minor, same fix as 1f7bca501a6608c51d799d9cb8f2c06d05cfe573. Also removes the elementary color theme from this page, which lets it use the site-wide Endless colors.