### PR TITLE
Minor build fixes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 * * * *' # Hourly
+    - cron: '0 0 * * 0' # Weekly
 
 jobs:
   build:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,13 +1,15 @@
 ---
 
-name: Update Data
+name: Regenerate App Data
 
 on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 0 * * 0' # Weekly
+    paths:
+      - 'appstream.xml'
+      - 'generate-eos-apps.rb'
+      - 'images/icons/'
 
 jobs:
   build:

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gem 'github-pages'
 gem 'jekyll-redirect-from'
 gem 'nokogiri'
+gem "webrick", "~> 1.7"

--- a/README.md
+++ b/README.md
@@ -10,54 +10,17 @@ Ideally we could download the data on demand when building, but for now I'm copy
 
 This site is a simple Jekyll-powered site hosted by GitHub Pages. To run it locally, see [the GitHub docs](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/).
 
-### Dependencies
-
-This guide assumes you're on elementary OS or a similar Ubuntu-based environment.
-
-#### Packages
-
-- `ruby-full` (should include `ruby` and `ruby-dev`)
-- `build-essential`
-- `zlib1g-dev`
-
-#### Ruby Stuff
-
-- `jekyll` and `bundler`
-
-We recommend installing gems to a (hidden) directory in your home folder:
-
-```shell
-echo '' >> ~/.bashrc
-echo '# Install Ruby Gems to ~/.gems' >> ~/.bashrc
-echo 'export GEM_HOME="$HOME/.gems"' >> ~/.bashrc
-echo 'export PATH="$HOME/.gems/bin:$PATH"' >> ~/.bashrc
-echo '' >> ~/.bashrc
-source ~/.bashrc
-```
-
-Install jekyll and bundler:
-
-```shell
-gem install jekyll bundler
-```
-
-Install gems:
-
-```shell
-bundle install
-```
-
-(Adapted from https://jekyllrb.com/docs/installation/)
+I recommend using `toolbox` to develop, especially if you're on Endless OS or Fedora Silverblue; see [this blog post](https://cassidyjames.com/blog/github-pages-jekyll-fedora-silverblue/) for details.
 
 ### Updating Apps
 
-The list of apps is generated with a simple Ruby script. To rebuild the app list, run:
+The list of apps is generated with a simple Ruby script. To rebuild the app list (e.g. if you've changed something in the Ruby script), run:
 
 ```shell
 ruby generate-eos-apps.rb
 ```
 
-This is automatically run hourly with a GitHub Action workflow.
+This script is also automatically run weekly with a GitHub Action workflow, though that's currently not really necessary since it's running against the same AppStream data each time.
 
 ### Serve
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The list of apps is generated with a simple Ruby script. To rebuild the app list
 ruby generate-eos-apps.rb
 ```
 
-This script is also automatically run weekly with a GitHub Action workflow, though that's currently not really necessary since it's running against the same AppStream data each time.
+This script is also automatically run on push to the `main` branch if the script itself, the AppStream data, or the icons change.
 
 ### Serve
 

--- a/generate-eos-apps.rb
+++ b/generate-eos-apps.rb
@@ -90,7 +90,7 @@ componentsData.css("components component").each do | component |
   end
   appFile.sub!('((bugtracker))', bugtracker)
 
-  color_primary = "#485a6c"
+  color_primary = "#f15a22"
   color_text = "#fff"
 
   custom_color = component.at_css('value[key="x-appcenter-color-primary"]')


### PR DESCRIPTION
Handful of things I noticed:

- Switches workflow to run on push to relevant files instead of always running hourly.
- Adds the explicit version of `webrick` to the Gemfile which fixes building on Fedora 36
- Updates the README to reflect reality, and recommends `toolbox` instead of outdated elementary OS instructions
- Updates the build script to use the Endless theme color for apps instead of a generic elementary slate color